### PR TITLE
Fixed DFC icon bug on front face of battle template

### DIFF
--- a/data/magic-m15-doublefaced-battle.mse-style/style
+++ b/data/magic-m15-doublefaced-battle.mse-style/style
@@ -33,39 +33,39 @@ card dpi: 150
 init script:
 	# Load scripts for image box
 	include file: /magic-default-image.mse-include/scripts
-	
+
 	# Should hybrids have a grey name?
 	mask_hybrid_with_land := { styling.grey_hybrid_name }
-	
+
 	#Should multicolor lands with basic land types have a colored name?
 	mask_multi_land_with_color := { styling.colored_multicolor_land_name }
-	
+
 	template_prefix := [card: "" card2: "" pt: "" pt2: "" stamp: "" identity: "/magic-identity-new.mse-include/"]
 	template_suffix := [card: "card.jpg" card2: "card2.jpg" pt: "pt.png", pt2: "pt2.png" stamp: "stamp.jpg" identity: "identity.png"]
 	template      := { template_prefix[type] + input + template_suffix[type] }
 	land_template := { template_prefix[type] + (if input == "a" then "c" else input) + "l" + template_suffix[type] }
 	# Use land templates for previews because they show more contrast
 	hybrid_previews := "hybrid"
-	
+
 	# This will create two seperate card faces
 	card_background2 := { color_background(type:"card2", base_hybrid:card_hybrid) }
 	card_ptbox2 := { color_background(type:"pt2", base_hybrid:pt_hybrid) }
-	
+
 	# Use the normal tap symbol
 	mana_t := {
 		if      styling.tap_symbol == "old"        then "old"
 		else if styling.tap_symbol == "diagonal T" then "older"
 		else                                            "new"
 	}
-	
+
 	# Use guild mana symbols?
 	guild_mana := { styling.use_guild_mana_symbols }
-	
+
 	typesymbol_for := { "none" }
-	
+
 	# Is the card a promo card?
 	is_promo := { styling.promo }
-	
+
 	# Is the second card face a creature?
 	has_pt_2 := { card.power_2 != "" or card.toughness_2 != "" }
 	has_identity := { styling.color_indicator_dot }
@@ -302,8 +302,8 @@ card style:
 	type symbol:
 		left: 17
 		top: 434
-		height: 31
-		width: 31
+		height: { if card.type_symbol_2 == "none" then 16 else 31 }
+		width: {if card.type_symbol_2 == "none" then 16 else 31 }
 		z index: 1
 		render style: image
 		choice images:
@@ -759,7 +759,7 @@ extra card style:
 			name: Relay-Medium
 			size: 7
 			color: white
-			weight: bold		
+			weight: bold
 	artist arrow:
 		left: { 28 + card_style.set_code.content_width }
 		top: 500


### PR DESCRIPTION
There was a visual bug where the dropdown menu for the front-face dfc icon would not display previews of any of the options for dfc icon. Further, when selecting any of them, no icon would be visible in the appropriate spot on the battle face. This error did not happen on the back face.

Investigating the stylesheet, the only discrepancy I could find was that the height and width for the front side was hardcoded, but the back side had the height and width gated behind an if/else. Copying that into the front face section fixed the problem.